### PR TITLE
Only allow FE to make requests to server

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,11 @@ mongoose.connect(process.env.DATABASE, {
 }).then(() => console.log("DB CONNECTED"))
   .catch((err) => console.log(err));
 
-app.use(cors());
+app.use(cors({
+  origin: "https://feelit.netlify.com/",
+  optionsSuccessStatus: 200 // some legacy browsers (IE11, various SmartTVs) choke on 204
+}));
+
 app.use(bodyParser.json());
 app.use(cookieParser());
 

--- a/app.js
+++ b/app.js
@@ -21,8 +21,8 @@ mongoose.connect(process.env.DATABASE, {
   .catch((err) => console.log(err));
 
 app.use(cors({
-  origin: "https://feelit.netlify.com/",
-  optionsSuccessStatus: 200 // some legacy browsers (IE11, various SmartTVs) choke on 204
+  origin: "https://feelit.netlify.com",
+  optionsSuccessStatus: 200
 }));
 
 app.use(bodyParser.json());


### PR DESCRIPTION
Added a stricter CORS policy that will only requests from our front-end domain (eg: https://feelit.netlify.com). Postman will still work for testing locally.

Closes #36 