### PR TITLE
add credentials to fix cors error

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,8 @@ mongoose.connect(process.env.DATABASE, {
 
 app.use(cors({
   origin: "https://feelit.netlify.com",
-  optionsSuccessStatus: 200
+  optionsSuccessStatus: 200,
+  credentials: true
 }));
 
 app.use(bodyParser.json());


### PR DESCRIPTION
This is needed for the `/check-auth` route where the fetch request includes credentials (in order to send the cookie). 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials